### PR TITLE
pass logger instance to provider constructor

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,10 @@
+var _ = require('underscore')
+
 module.exports = function (reporter, definition) {
   if (reporter.options.connectionString.name.toLowerCase() === 'nedb') {
-    reporter.documentStore.provider = new (require('./embeddedProvider'))(reporter.documentStore.model, reporter.options);
+    reporter.documentStore.provider = new (require('./embeddedProvider'))(
+      reporter.documentStore.model,
+      _.extend({}, reporter.options, { logger: reporter.logger })
+    )
   }
 };


### PR DESCRIPTION
since we are ensuring that `reporter.options.logger` is not the logger instance anymore, we must explicitly pass the logger instance.

altought this package is deprecated i tought it would be ok if we mantain the consistency like in other stores implementations.